### PR TITLE
Fix manifest auth and bump version

### DIFF
--- a/custom_components/dropboxbackup/__init__.py
+++ b/custom_components/dropboxbackup/__init__.py
@@ -2,9 +2,9 @@
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.components.backup import BackupAgent, BackupAgentError
+
 from .backup import async_register_backup_agents_listener
-from .const import DOMAIN, DATA_BACKUP_AGENT_LISTENERS
+from .const import DATA_BACKUP_AGENT_LISTENERS
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/dropboxbackup/backup.py
+++ b/custom_components/dropboxbackup/backup.py
@@ -51,7 +51,13 @@ class DropboxBackupAgent(BackupAgent):
         try:
             # 4) Refresh token (new signature takes only token_data)
             session = await impl.async_refresh_token(token_data)
-            _LOGGER.debug("Session returned by async_refresh_token: %s", session)  # ⑥
+            _LOGGER.debug(
+                "Session returned by async_refresh_token: %s", session
+            )  # ⑥
+
+            # Persist the refreshed token so future calls use the new values
+            new_data = {**self.entry.data, "token": session}
+            self.hass.config_entries.async_update_entry(self.entry, data=new_data)
         except Exception as e:
             _LOGGER.error("async_refresh_token failed: %s", e, exc_info=True)  # ⑦
             raise

--- a/custom_components/dropboxbackup/config_flow.py
+++ b/custom_components/dropboxbackup/config_flow.py
@@ -13,7 +13,7 @@ class DropboxOAuth2FlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
     """Handle OAuth2 for Dropbox Backup via Application Credentials."""
 
     DOMAIN = DOMAIN
-    CLIENT_ID = "dropbox"  # must match the 'auth' name in manifest.json
+    CLIENT_ID = "dropbox"  # must match the entry in application_credentials
     SCOPE = [
         "files.content.read",
         "files.content.write",

--- a/custom_components/dropboxbackup/manifest.json
+++ b/custom_components/dropboxbackup/manifest.json
@@ -8,8 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/jasonwragg/HA-Dropbox-Backup/issues",
   "requirements": ["dropbox>=11.0.0"],
-  "version": "1.0.6",
-  "auth": [
-    { "name": "dropbox", "type": "oauth2" }
-  ]
+  "version": "1.0.7"
 }


### PR DESCRIPTION
## Summary
- remove invalid `auth` block from `manifest.json`
- bump integration version to 1.0.7
- update OAuth comment in `config_flow`
- clean unused imports
- persist refreshed OAuth token in the config entry

## Testing
- `ruff check .`
- `scripts/setup` *(fails: Could not find a version that satisfies the requirement homeassistant>=2025.1.0)*